### PR TITLE
Quick fix on model TGOV1NDB

### DIFF
--- a/andes/models/governor/tgov1.py
+++ b/andes/models/governor/tgov1.py
@@ -138,7 +138,7 @@ class TGOV1NDBModel(TGOV1DBModel):
         self.pref.v_str = 'tm0'
         self.pref.e_str = 'pref0 - pref'
 
-        self.pd.e_str = 'ue*(DB_y * gain + pref + paux) - pd'
+        self.pd.e_str = 'ue*(-DB_y * gain + pref + paux) - pd'
 
 
 class TGOV1ModelAlt(TGBase):

--- a/docs/source/release-notes.rst
+++ b/docs/source/release-notes.rst
@@ -45,7 +45,7 @@ Other changes:
 - Add method ``GroupBase.get_all_idxes()`` to get all indices of a group.
 - Enhanced three-winding transformer parsing in PSS/E raw files by assigning the equivalent star bus ``area``,
   ``owner``, and ``zone`` using the high-voltage bus values.
-- Specify `multiprocess<=0.70.16` in requirements as 0.70.17 does not support Linux.
+- Minor fix on model ``TGOV1NDB``
 
 v1.9.2 (2024-03-25)
 -------------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,3 @@ chardet
 psutil
 texttable
 numba
-multiprocess <=0.70.16


### PR DESCRIPTION
There should be a minus sign for the var ``DB_y``:

https://github.com/CURENT/andes/blob/5ab784b75347a98d07c004e32d7c4b39d407ea2e/andes/models/governor/tgov1.py#L141

Before fix:
![Pasted Graphic 1](https://github.com/user-attachments/assets/f71e8aad-26c9-418a-b211-0fb579f41d71)

After fix:
![Pasted Graphic](https://github.com/user-attachments/assets/faefadb8-091a-4d59-b782-19abfb753f2a)
