### PR TITLE
pvd1 model debug

### DIFF
--- a/andes/models/distributed/pvd1.py
+++ b/andes/models/distributed/pvd1.py
@@ -324,7 +324,7 @@ class PVD1Model(Model):
                           unit='Hz', tex_name='f_{dev}',
                           )
 
-        self.DB = DeadBand1(u=self.Fdev, center=0.0, lower=self.fdbd, upper=0.0, gain=self.ddn,
+        self.DB = DeadBand1(u=self.Fdev, center=0.0, lower=self.fdbd, upper=999.0, gain=self.ddn,
                             info='frequency deviation deadband with gain',
                             )  # outputs   `Pdrp`
         self.DB.db.no_warn = True


### PR DESCRIPTION
PVD1 is designed to only support down regulation frequency droop. Please set the upper frequency deadband to 999 to effectively disable up regulation frequency droop.